### PR TITLE
Strange label after problem

### DIFF
--- a/autonum.dtx
+++ b/autonum.dtx
@@ -348,8 +348,8 @@ and the derived files           autonum.ins,
 %    \end{macrocode}
 		% The commented and the uncommented lines should do the same. The longer variant has the advantage, that there is no error the first run after the deactivation of the autonum package, as \cmd{\xdef}, read from the aux file, is always a known command, whereas \cmd{\csxdef} might not be known in that case, as with the deactivation of autonum it might happen, that etoolbox is not loaded anymore, too.
 %    \begin{macrocode}
-% 		\csxdef{\detokenize{#1}}{#2}%
-		\expandafter\string\expandafter\xdef\expandafter\string\csname #1\endcsname{#2}%
+		\csxdef{\detokenize{#1}}{#2}%
+%		\expandafter\string\expandafter\xdef\expandafter\string\csname #1\endcsname{#2}%
 	}%
 }
 %    \end{macrocode}

--- a/test-autonum.tex
+++ b/test-autonum.tex
@@ -51,6 +51,11 @@
 			\begin{equation}\label{äöüÄÖÜß?:, 3075µ!/§}
 				\sqrt{b}
 			\end{equation}
+		\item Having a labeled equation with a very strange label after
+			\begin{equation}\label{äöüÄÖÜß?:, 3075µ!/§:two}
+				\sqrt{b}
+			\end{equation}
+			\ref{äöüÄÖÜß?:, 3075µ!/§:two}
 		\item Check for spurious whitespace around reference (\ref{checkWhitespace})
 			\begin{equation}\label{checkWhitespace}
 				b_c


### PR DESCRIPTION
I don't know enough about low-level LaTeX, but `\expandafter\string\expandafter\xdef\expandafter\string\csname #1\endcsname` with `#1`=`foo` expands to `\xdef\foo`, however inserting another `\expandafter` before `\csname` expands to `\xdef\csnamefoo\endcsname`, I haven't figured out how to insert a space after `\csname`, which would solve the problem that `\csxdef` might not exist…
