### PR TITLE
incease compatibility of autonum

### DIFF
--- a/autonum.dtx
+++ b/autonum.dtx
@@ -89,12 +89,6 @@ and the derived files           autonum.ins,
 \PassOptionsToPackage{hypertexnames=false}{hyperref}
 \RequirePackage{etoolbox}
 %
-% Avoid \href{https://groups.google.com/d/msg/comp.text.tex/VRrFB4ll5n0/Vu31OC4hQG8J}{a conflict} between etoolbox and etextools
-\makeatletter % The missing \makeatother command is on purpose (as every other combination results in an error).
-\let\autonum@etoolbox@forlistloop\forlistloop
-\RequirePackage{etextools}
-\let\forlistloop\autonum@etoolbox@forlistloop
-%
 \RequirePackage{amsmath}
 \RequirePackage[absolute]{textpos}
 \RequirePackage{letltxmacro}
@@ -631,6 +625,27 @@ and the derived files           autonum.ins,
 %    \end{macrocode}
 %\end{macro}
 
+% \begin{macro}{\aftergroup@def}
+% Provide the \cmd{\aftergroup@def} command originally defined in the \cmd{etextools} package
+%    \begin{macrocode}
+\ifdefcounter{\ettl@fter}{}{\newcount\ettl@fter}
+\providerobustcmd*\aftergroup@def{\@ifstar\aftergroup@defstar\aftergroup@d@f}
+\providerobustcmd*\@ftergroup@def[3]{%
+   \aftergroup#2\aftergroup#3\aftergroup#1%
+   \aftergroup\global \aftergroup\undef \aftergroup#1}
+\providerobustcmd*\aftergroup@defstar[1]{%
+   \global\expandafter\let\csname ettl@ftergroup@def\the\numexpr\ettl@fter+1\endcsname#1%
+   \global\advance\ettl@fter\@ne
+   \expandafter\@ftergroup@def\csname ettl@ftergroup@def\the\ettl@fter\endcsname\let#1}
+\providerobustcmd*\aftergroup@d@f[1]{%
+   \let\etex@let@primitive\let   \def\let{\global\etex@let@primitive}%
+   \expandafter\LetLtxMacro\csname ettl@ftergroup@def\the\numexpr\ettl@fter+1\endcsname#1%
+   \global\advance\ettl@fter\@ne
+   \etex@let@primitive\let=\etex@let@primitive
+   \expandafter\@ftergroup@def\csname ettl@ftergroup@def\the\ettl@fter\endcsname\LetLtxMacro#1}%
+%    \end{macrocode}
+% \end{macro}
+
 % This is needed to not get overwritten by other packages. The package autonum only overwrites some commands whose name start with \cmd{\autonum}. Other commands are only patched, so the currently valid command gets called, too. So although not very polite, this behavior seems reasonable.
 %    \begin{macrocode}
 \AtBeginDocument{%
@@ -664,6 +679,8 @@ and the derived files           autonum.ins,
 	\autonum@generatePatchedReference{ref}%
 	\ifdef{\cref}{%
 		\autonum@generatePatchedReferenceCSL{cref}%
+		\autonum@generatePatchedReferenceCSL{Cref}%
+		\autonum@generatePatchedReferenceCSL{labelcref}%
 	}{}%
 %    \end{macrocode}
 %    \begin{macrocode}

--- a/test-autonum.tex
+++ b/test-autonum.tex
@@ -28,11 +28,11 @@
 \usepackage{autonum}
 
 % This package is not needed and can be uncommented at any time. Loading it ensures that conflicts between this package and autonum (being involved by loading etoolbox and etextools) are detected.
-\usepackage[backend=bibtex]{biblatex}
+\usepackage{biblatex}
 % Deactivate a warning from biblatex, as the package is intentionally not used in this document.
-\makeatletter
-\def\blx@ifsigned#1#2#3#4{}%
-\makeatother
+% \makeatletter
+% \def\blx@ifsigned#1#2#3#4{}%
+% \makeatother
 
 \newcounter{Hequation}
 \renewcommand{\theHequation}{\thechapter.\arabic{Hequation}}
@@ -98,10 +98,11 @@
 			\begin{equation}\label{unreferenced}
 				\sqrt{a}
 			\end{equation}
-		\item Having a labeled equation with a very strange label \ref{äöüÄÖÜß?:, 3075µ!/§} does only work without package inputenx
-			\begin{equation}\label{äöüÄÖÜß?:, 3075µ!/§}
-				\sqrt{b}
-			\end{equation}
+% 		\item Having a labeled equation with a very strange label \ref{äöüÄÖÜß?:, 3075µ!/§} does only work without package inputenx
+% 			\begin{equation}
+% 			\label{äöüÄÖÜß?:, 3075µ!/§}
+% 				\sqrt{b}
+% 			\end{equation}
 		\item Having a labeled equation with a colon in the label \ref{label:colon}
 			\begin{equation}\label{label:colon}
 				\sqrt{c}
@@ -115,10 +116,11 @@
 				\sqrt{e}\label{referenceAfter:colon}
 			\end{equation}
 			and referencing \ref{referenceAfter:colon} only afterwards
-		\item Having a labeled equation with umlauts in the label \ref{äöüÄÖÜßLabel}
-			\begin{equation}\label{äöüÄÖÜßLabel}
-				\sqrt{c}
-			\end{equation}
+% 		\item Having a labeled equation with umlauts in the label \ref{äöüÄÖÜßLabel}
+% 			\begin{equation}
+% 			\label{äöüÄÖÜßLabel}
+% 				\sqrt{c}
+% 			\end{equation}
 		\item Check for spurious whitespace around reference (\ref{checkWhitespace})
 			\begin{equation}\label{checkWhitespace}
 				b_c
@@ -159,6 +161,16 @@
 					g
 				\end{equation}
 				\cref{crefOne}
+			\item Using Cref with one argument
+				\begin{equation}\label{CrefOne}
+					g
+				\end{equation}
+				\Cref{CrefOne}
+			\item Using labelcref with one argument
+				\begin{equation}\label{labelcrefOne}
+					g
+				\end{equation}
+				\labelcref{labelcrefOne}
 			\item Using cref with two arguments
 				\begin{equation}\label{crefTwo}
 					cr = ef


### PR DESCRIPTION
the etextools package loaded by autonum conflicts with biblatex.
However only a single command from etextools is used in autonum.
Therefore I propose to remove the dependency and provide the command within autonum.

Furthermore, autonum is compatible with cleveref. 
However not with all its commands. I have added compatibility with Cref and labelcref.

The test containing Umlaute fails however, as far as I know this is not supposed to work within Latex.
Therefore I have commented  out these test.